### PR TITLE
Add ability to have the menu stay open / close on sound selection.

### DIFF
--- a/chroma-enginesoundmenu/client.lua
+++ b/chroma-enginesoundmenu/client.lua
@@ -16,26 +16,32 @@ lib.registerMenu({
     }
 }, function(selected, scrollIndex, args)
     if not cache.vehicle or cache.seat ~= -1 then
-        return Config.Notify('You need to be driving a vehicle to use this!', 'error') 
+        return Config.Notify('You need to be driving a vehicle to use this!', 'error')
     end
-    
+
     TriggerServerEvent('Chroma:EngineSounds:ChangeEngineSound', {
         net = VehToNet(cache.vehicle),
         sound = Config.EngineSounds[DisplayLabels[scrollIndex]]
     })
 
     Config.Notify(string.format('Engine sound changed to: %s', DisplayLabels[scrollIndex]), 'success')
-
 end)
 
 RegisterNetEvent("Chroma:EngineSounds:OpenMenu", function()
     if not cache.vehicle or cache.seat ~= -1 then
-        return Config.Notify('You need to be driving a vehicle to use this!', 'error') 
+        return Config.Notify('You need to be driving a vehicle to use this!', 'error')
     end
 
-    lib.setMenuOptions('engine_sound_menu', { label = 'Change Engine Sound', icon = 'arrows-up-down-left-right', values = DisplayLabels, defaultIndex = Index, close = false }, 1)
+    lib.setMenuOptions('engine_sound_menu',
+        {
+            label = 'Change Engine Sound',
+            icon = 'arrows-up-down-left-right',
+            values = DisplayLabels,
+            defaultIndex = Index,
+            close = Config.CloseOnSelect
+        },
+        1)
     lib.showMenu('engine_sound_menu')
-
 end)
 
 AddStateBagChangeHandler("vehdata:sound", nil, function(bagName, key, value)

--- a/chroma-enginesoundmenu/client.lua
+++ b/chroma-enginesoundmenu/client.lua
@@ -33,7 +33,7 @@ RegisterNetEvent("Chroma:EngineSounds:OpenMenu", function()
         return Config.Notify('You need to be driving a vehicle to use this!', 'error') 
     end
 
-    lib.setMenuOptions('engine_sound_menu', { label = 'Change Engine Sound', icon = 'arrows-up-down-left-right', values = DisplayLabels, defaultIndex = Index }, 1)
+    lib.setMenuOptions('engine_sound_menu', { label = 'Change Engine Sound', icon = 'arrows-up-down-left-right', values = DisplayLabels, defaultIndex = Index, close = false }, 1)
     lib.showMenu('engine_sound_menu')
 
 end)

--- a/chroma-enginesoundmenu/client_config.lua
+++ b/chroma-enginesoundmenu/client_config.lua
@@ -1,6 +1,7 @@
 Config = {
-    Keybind = "", -- E.G F7 ---> https://docs.fivem.net/docs/game-references/controls/
+    Keybind = "",                  -- E.G F7 ---> https://docs.fivem.net/docs/game-references/controls/
     MenuPosition = "bottom-right", -- bottom-right, bottom-left, top-right, top-left
+    CloseOnSelect = false,         -- Will close the menu when you select an engine sound.
     Notify = function(msg, type)
         -- customise this notification function to whatever you desire - by default it uses ox_lib but you can edit this
         lib.notify({


### PR DESCRIPTION
Very minor edit, but when using the menu for myself found it nicer to be able to keep the menu open when scrolling through sounds.
Added configuration for the PR to align with the rest of the configurability of the script.